### PR TITLE
Persist SQLite data in dedicated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 client/node_modules
 server/node_modules
 client/dist
-server/data.db
+server/data/
 npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY server/package*.json server/
 RUN cd server && npm install
 COPY server ./server
 COPY --from=build-client /app/client/dist ./server/public
+RUN mkdir -p /app/server/data && chown -R node:node /app/server/data
 WORKDIR /app/server
 EXPOSE 3000
 CMD ["npm","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./server/data.db:/app/server/data.db
+      - ./server/data:/app/server/data

--- a/server/src/db.js
+++ b/server/src/db.js
@@ -1,5 +1,11 @@
 const Database = require('better-sqlite3');
-const db = new Database('data.db');
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(__dirname, 'data');
+fs.mkdirSync(dataDir, { recursive: true });
+const dbPath = path.join(dataDir, 'data.db');
+const db = new Database(dbPath);
 db.pragma('foreign_keys = ON');
 db.exec(`
 CREATE TABLE IF NOT EXISTS projects (


### PR DESCRIPTION
## Summary
- store database in server/data, creating folder when necessary
- allow `node` user to write by preparing data dir in Dockerfile
- mount persistent data folder in docker-compose

## Testing
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895d355f46c832e88c50d20e0334d10