### PR TITLE
Add catch-all route for SPA

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -81,5 +81,9 @@ app.delete('/api/positions/:id', (req,res)=>{
   res.json({status:'ok'});
 });
 
+app.get('*', (_, res) =>
+  res.sendFile(path.join(__dirname, '../public/index.html'))
+);
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, ()=> console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add wildcard route to return index.html for non-API requests

## Testing
- `npm test` *(fails: Error: no test specified)*
- `docker-compose up --build -d` *(fails: Connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6896134aede0832ea1450b692f07a2bd