### PR TITLE
fix: make express fallback route compatible with v5

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -81,7 +81,7 @@ app.delete('/api/positions/:id', (req,res)=>{
   res.json({status:'ok'});
 });
 
-app.get('*', (_, res) =>
+app.use((_, res) =>
   res.sendFile(path.join(__dirname, '../public/index.html'))
 );
 


### PR DESCRIPTION
## Summary
- ensure server fallback route uses Express 5 compatible syntax

## Testing
- `npm test`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68961cddf960832eac2d1f013c5c6889